### PR TITLE
Repository pages should now allow scoped searching by repository

### DIFF
--- a/app/components/arclight/search_bar_component.html.erb
+++ b/app/components/arclight/search_bar_component.html.erb
@@ -9,7 +9,13 @@
       <label class="input-group-text" for="within_collection">
         <%= t('arclight.within_collection_dropdown.label_html') %>
       </label>
-      <%= select_tag ('f[collection][]' if collection_name.present?), within_collection_options, id: 'within_collection', class: 'form-select search-field rounded-end' %>
+      <% if collection_name.present? %>
+        <%= select_tag 'f[collection][]', within_collection_options, id: 'within_collection', class: 'form-select search-field rounded-end' %>
+      <% elsif repository_name.present? %>
+        <%= select_tag 'f[repository][]', within_collection_options, id: 'within_collection', class: 'form-select search-field rounded-end' %>
+      <% else %>
+        <%= select_tag ('f[collection][]' if collection_name.present?), within_collection_options, id: 'within_collection', class: 'form-select search-field rounded-end' %>
+      <% end %>
     </div>
   <% end %>
 

--- a/app/components/arclight/search_bar_component.rb
+++ b/app/components/arclight/search_bar_component.rb
@@ -13,22 +13,36 @@ module Arclight
     end
 
     def within_collection_options
-      value = collection_name || 'none-selected'
+      all_collections_option = [t('arclight.within_collection_dropdown.all_collections'), '']
+      this_collection_option = [t('arclight.within_collection_dropdown.this_collection'), collection_name || 'none-selected']
+      this_repository_option = [t('arclight.within_collection_dropdown.this_repository'), repository_name].compact
+
+      options = [all_collections_option]
+      options << this_collection_option if collection_name.present?
+      options << this_repository_option if repository_name.present?
+
       options_for_select(
-        [
-          [t('arclight.within_collection_dropdown.all_collections'), ''],
-          [t('arclight.within_collection_dropdown.this_collection'), value]
-        ],
-        selected: collection_name,
+        options,
+        selected: selected_option(options),
         disabled: 'none-selected'
-
       )
-
     end
 
     def collection_name
       @collection_name ||= Array(@params.dig(:f, :collection)).reject(&:empty?).first ||
                            helpers.current_context_document&.collection_name
+    end
+
+    def repository_name
+      if controller.controller_name == "repositories" && controller.action_name == "show"
+          @repository_name ||= Repository.find_by!(slug: params[:id]).name
+      else
+        @repository_name ||= Array(@params.dig(:f, :repository)).reject(&:empty?).first      
+      end
+    end
+
+    def selected_option(options)
+      options.detect { |option| option.last.present? }&.last || ''
     end
   end
 end

--- a/config/locales/arclight.en.yml
+++ b/config/locales/arclight.en.yml
@@ -1,4 +1,7 @@
 en:
+  arclight:
+    within_collection_dropdown:
+      this_repository: this repository
   blacklight:
     search:
       fields:


### PR DESCRIPTION
This mimics the scoped collection searching by making "this repository" the default while on repository pages.

If you want it to literally say the repository name, [this line](https://github.com/gwiedeman/ArclightEmpireADC/blob/main/app/components/arclight/search_bar_component.rb#L18) just has to be changed to this:
```
this_repository_option = [repository_name, repository_name].compact
```